### PR TITLE
Fix for 'accessory.deviceURL == null' case

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ TahomaPlatform.prototype = {
         	baseURL = deviceURL.substring(0, i1);
 					//this.log.info('Search extended : ' + baseURL);
         	for (accessory of this.platformAccessories) {
-				if (accessory.deviceURL.startsWith(baseURL))
+				if (accessory.deviceURL != null && accessory.deviceURL.startsWith(baseURL))
 				return accessory;
 			}
         }


### PR DESCRIPTION
Fix for 'accessory.deviceURL == null' case in case of scenarios. 
```
/usr/lib/node_modules/homebridge-tahoma/index.js:50
                                if (accessory.deviceURL.startsWith(baseURL))
                                                        ^
TypeError: Cannot read property 'startsWith' of undefined
```