### PR TITLE
Workaround for ClosureState=99 instead of 100%

### DIFF
--- a/accessories/Awning.js
+++ b/accessories/Awning.js
@@ -241,14 +241,13 @@ Awning.prototype = {
     },
 
     onStateUpdate: function(name, value) {
-    	if (name == 'core:ClosureState' || name == 'core:TargetClosureState') {
-			var converted = 100 - value;
-			if(this.device.widget.startsWith('PositionableHorizontal') || this.device.widget == 'PositionableScreen') {
-				converted = value;
-			}
-			this.currentPosition.updateValue(converted);
-			if (!this.isCommandInProgress()) // if no command running, update target
-				this.targetPosition.updateValue(converted);
+        if (name == 'core:ClosureState' || name == 'core:TargetClosureState') {
+            if (value == 99) // Workaround for io:RollerShutterVeluxIOComponent  remains 1% opened
+                value = 100;
+            var converted = 100 - value;
+            this.currentPosition.updateValue(converted);
+            if (!this.isCommandInProgress()) // if no command running, update target
+                this.targetPosition.updateValue(converted);
 		} else if (name == 'core:DeploymentState') {
 			this.currentPosition.updateValue(value);
 			if (!this.isCommandInProgress()) // if no command running, update target


### PR DESCRIPTION
Workaround to fix wrong ClosureState=99 instead of 100% reported by the Tahoma API (io:RollerShutterVeluxIOComponent)

**Before**
```
[2018-6-15 23:10:28] [Connexoon] [Volet Velux] core:ClosureState=99
[2018-6-15 23:10:28] [Connexoon] [Volet Velux] core:OpenClosedState=open
```

**After**
```
[2018-9-26 00:00:21] [Connexoon] [Volet Velux] setClosure[100]
[2018-9-26 00:00:21] [Connexoon] [Volet Velux] setClosure INITIALIZED
[2018-9-26 00:00:21] [Connexoon] Register listener
[2018-9-26 00:00:22] [Connexoon] [Volet Velux] setClosure IN_PROGRESS
[2018-9-26 00:00:24] [Connexoon] [Volet Velux] setClosure COMPLETED
```

