### PR TITLE
Add device type as exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Configuration parameters:
 | `service`              	 | String		| 'TaHoma'			| optional, service name ('TaHoma', 'Connexoon', 'Connexoon RTS', 'Cozytouch' or 'Rexel')																																																											|
 | `refreshPeriod`            | Integer	| 1800					| optional, device states refresh period in seconds							 																										 																										|
 | `pollingPeriod`            | Integer	| 0						| optional, bridge polling period in seconds for sensors events (0: no polling)							 																										 																										|
-| `exclude`		             | String[]	| []					| optional, list of protocols (hue,enocean,zwave,io,rts) or device (name) to exclude																																										|
+| `exclude`		             | String[]	| []					| optional, list of protocols (hue,enocean,zwave,io,rts), device types (eg. RollerShutter) or device (name) to exclude																																										|
 | `exposeScenarios`	         | Boolean	| false					| optional, expose TaHoma/Connexoon/Cozytouch scenarios as HomeKit switches. Could also specify a list of string corresponding to scenarios names to expose												|
 | `forceType`		         | Object		| {}				| optional, list of device (name) to force with another type (see below). Ex. Fan recognised as Light can be force to Fan type											|
 | `Alarm`		             | Object		| {}				| optional, Alarm configuration object (see below)										|

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Configuration parameters:
 | `service`              	 | String		| 'TaHoma'			| optional, service name ('TaHoma', 'Connexoon', 'Connexoon RTS', 'Cozytouch' or 'Rexel')																																																											|
 | `refreshPeriod`            | Integer	| 1800					| optional, device states refresh period in seconds							 																										 																										|
 | `pollingPeriod`            | Integer	| 0						| optional, bridge polling period in seconds for sensors events (0: no polling)							 																										 																										|
-| `exclude`		             | String[]	| []					| optional, list of protocols (hue,enocean,zwave,io,rts), device types (eg. RollerShutter) or device (name) to exclude																																										|
+| `exclude`		             | String[]	| []					| optional, list of protocols (hue,enocean,zwave,io,rts), device types (eg. RollerShutter), device definitions (eg. WindowCovering) or device (name) to exclude																																										|
 | `exposeScenarios`	         | Boolean	| false					| optional, expose TaHoma/Connexoon/Cozytouch scenarios as HomeKit switches. Could also specify a list of string corresponding to scenarios names to expose												|
 | `forceType`		         | Object		| {}				| optional, list of device (name) to force with another type (see below). Ex. Fan recognised as Light can be force to Fan type											|
 | `Alarm`		             | Object		| {}				| optional, Alarm configuration object (see below)										|

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ TahomaPlatform.prototype = {
 					for (device of data) {
 						var protocol = device.controllableName.split(':').shift(); // Get device protocol name
 						Log.info('[' + device.label + ']' + ' type: ' + device.uiClass + ' > ' + device.widget + ', protocol: ' + protocol);
-						if(that.exclusions.indexOf(protocol) == -1 && that.exclusions.indexOf(device.label) == -1) {
+						if(that.exclusions.indexOf(protocol) == -1 && that.exclusions.indexOf(device.uiClass) == -1 && that.exclusions.indexOf(device.label) == -1) {
 							device = new OverkizDevice(Homebridge, Log, this.api, device);
 							var deviceDefinition = mapping[device.widget];
 							if(deviceDefinition == undefined) {

--- a/index.js
+++ b/index.js
@@ -124,16 +124,17 @@ TahomaPlatform.prototype = {
 					Log.debug(data.length + ' device(s) found');
 					for (device of data) {
 						var protocol = device.controllableName.split(':').shift(); // Get device protocol name
-						Log.info('[' + device.label + ']' + ' type: ' + device.uiClass + ' > ' + device.widget + ', protocol: ' + protocol);
-						if(that.exclusions.indexOf(protocol) == -1 && that.exclusions.indexOf(device.uiClass) == -1 && that.exclusions.indexOf(device.label) == -1) {
-							device = new OverkizDevice(Homebridge, Log, this.api, device);
-							var deviceDefinition = mapping[device.widget];
-							if(deviceDefinition == undefined) {
-								deviceDefinition = mapping[device.uiClass];
-							}
-							if(deviceDefinition == undefined) {
-								Log.info('No definition found for ' + device.uiClass + ' > ' + device.widget + ' in mapping.json file');
-							} else {
+            Log.info('[' + device.label + ']' + ' type: ' + device.uiClass + ' > ' + device.widget + ', protocol: ' + protocol);
+            var deviceDefinition = mapping[device.widget];
+						if(deviceDefinition == undefined) {
+							deviceDefinition = mapping[device.uiClass];
+						}
+						if(deviceDefinition == undefined) {
+							Log.info('No definition found for ' + device.uiClass + ' > ' + device.widget + ' in mapping.json file');
+						} else {
+  						if(that.exclusions.indexOf(protocol) == -1 && that.exclusions.indexOf(device.uiClass) == -1 && that.exclusions.indexOf(deviceDefinition) == -1 && that.exclusions.indexOf(device.label) == -1) {
+  							device = new OverkizDevice(Homebridge, Log, this.api, device);
+							
 								var forced = this.forceType[device.name] || this.forceType[device.widget];
 								var widgetConfig = this.config[device.widget] || {};
 								var services = [];
@@ -174,10 +175,10 @@ TahomaPlatform.prototype = {
 									}
 								}
 								this.platformDevices.push(device);
-							}
-						} else {
-							Log.info('Device ' + device.label + ' ignored');
-						}
+							} else {
+							  Log.info('Device ' + device.label + ' ignored');
+              }
+            }
 					}
 
 					this.platformDevices.sort(function(a, b) {


### PR DESCRIPTION
Since TaHoma now has an official support for some HomeKit devices it would be great when we could exclude a certain device type instead of a protocol or name. 