### PR TITLE
Add widget type as another exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Configuration parameters:
 | `service`              	 | String		| 'TaHoma'			| optional, service name ('TaHoma', 'Connexoon', 'Connexoon RTS', 'Cozytouch' or 'Rexel')																																																											|
 | `refreshPeriod`            | Integer	| 1800					| optional, device states refresh period in seconds							 																										 																										|
 | `pollingPeriod`            | Integer	| 0						| optional, bridge polling period in seconds for sensors events (0: no polling)							 																										 																										|
-| `exclude`		             | String[]	| []					| optional, list of protocols (hue,enocean,zwave,io,rts), device types (eg. RollerShutter), device definitions (eg. WindowCovering) or device (name) to exclude																																										|
+| `exclude`		             | String[]	| []					| optional, list of protocols (hue,enocean,zwave,io,rts), device types (eg. RollerShutter), device definitions (eg. WindowCovering), widget types (e.g. PositionableExteriorVenetianBlind) or devices (names) to exclude																																										|
 | `exposeScenarios`	         | Boolean	| false					| optional, expose TaHoma/Connexoon/Cozytouch scenarios as HomeKit switches. Could also specify a list of string corresponding to scenarios names to expose												|
 | `forceType`		         | Object		| {}				| optional, list of device (name) to force with another type (see below). Ex. Fan recognised as Light can be force to Fan type											|
 | `Alarm`		             | Object		| {}				| optional, Alarm configuration object (see below)										|

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ TahomaPlatform.prototype = {
 						if(deviceDefinition == undefined) {
 							Log.info('No definition found for ' + device.uiClass + ' > ' + device.widget + ' in mapping.json file');
 						} else {
-  						if(that.exclusions.indexOf(protocol) == -1 && that.exclusions.indexOf(device.uiClass) == -1 && that.exclusions.indexOf(deviceDefinition) == -1 && that.exclusions.indexOf(device.label) == -1) {
+						if(that.exclusions.indexOf(protocol) == -1 && that.exclusions.indexOf(device.uiClass) == -1 && that.exclusions.indexOf(deviceDefinition) == -1 && that.exclusions.indexOf(device.label) == -1 && that.exclusions.indexOf(device.widget) == -1) {
   							device = new OverkizDevice(Homebridge, Log, this.api, device);
 							
 								var forced = this.forceType[device.name] || this.forceType[device.widget];


### PR DESCRIPTION
This can be useful in situations where both RTS and io variants of the
same device type are used in a single installation and only the io-based
devices should be excluded, but there are other io devices which should
remain.

Example:
device 1: type: ExteriorVenetianBlind > UpDownExteriorVenetianBlind, protocol: rts
device 2: type: ExteriorVenetianBlind > PositionableExteriorVenetianBlind, protocol: io
device 3: type: ContactSensor > ContactSensor, protocol: io

Goal: exclude only devices of type 2 (without using the device name)

Previous options:
- exclude "io": would exclude devices 2+3
- exclude "ExteriorVenetianBlind": would exclude devices 1+2

New option: exclude "PositionableExteriorVenetianBlind" to target only
devices of type 2.