### PR TITLE
Allow to change DHWP Calypso's temperature (5 to 7 showers).

### DIFF
--- a/src/mappers/WaterHeatingSystem/DomesticHotWaterProduction/AtlanticDomesticHotWaterProductionV2_SPLIT_IOComponent.ts
+++ b/src/mappers/WaterHeatingSystem/DomesticHotWaterProduction/AtlanticDomesticHotWaterProductionV2_SPLIT_IOComponent.ts
@@ -9,13 +9,15 @@ export default class AtlanticDomesticHotWaterProductionV2_SPLIT_IOComponent exte
         this.targetTemperature?.setProps({
             minValue: 50.0,
             maxValue: 54.5,
-            minStep: 0.5,
+            validValues: [50, 52, 54, 54.5, 55],
+            minStep: 2,
         });
         return service;
     }
 
     protected getTargetTemperatureCommands(value): Command | Array<Command> {
-        return new Command('setTargetTemperature', value);
+        const safeValue = value === 54 ? 54.5 : value;
+        return new Command('setTargetTemperature', safeValue);
     }
 
     protected getTargetStateCommands(value): Command | Array<Command> | undefined {

--- a/src/mappers/WaterHeatingSystem/DomesticHotWaterProduction/AtlanticDomesticHotWaterProductionV2_SPLIT_IOComponent.ts
+++ b/src/mappers/WaterHeatingSystem/DomesticHotWaterProduction/AtlanticDomesticHotWaterProductionV2_SPLIT_IOComponent.ts
@@ -1,20 +1,21 @@
-import { Command } from 'overkiz-client';
-import { Characteristics } from '../../../Platform';
+import {Command} from 'overkiz-client';
+import {Characteristics} from '../../../Platform';
 import DomesticHotWaterProduction from '../DomesticHotWaterProduction';
-import {Perms} from 'homebridge';
 
 export default class AtlanticDomesticHotWaterProductionV2_SPLIT_IOComponent extends DomesticHotWaterProduction {
 
     protected registerThermostatService() {
         const service = super.registerThermostatService();
-        const targetTemperature = this.device.getNumber('core:TargetTemperatureState');
         this.targetTemperature?.setProps({
-            minValue: targetTemperature,
-            maxValue: targetTemperature,
+            minValue: 50.0,
+            maxValue: 54.5,
             minStep: 0.5,
-            perms: [Perms.PAIRED_READ, Perms.EVENTS],
         });
         return service;
+    }
+
+    protected getTargetTemperatureCommands(value): Command | Array<Command> {
+        return new Command('setTargetTemperature', value);
     }
 
     protected getTargetStateCommands(value): Command | Array<Command> | undefined {


### PR DESCRIPTION
J'ai deux soucis : 

une erreur à l'execution, bien qu'elle se passe correctement : 
```
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] setTargetTemperature NOT_TRANSMITTED
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] setTargetTemperature TRANSMITTED
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] core:TemperatureState => 50.0
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] core:TargetTemperatureState => 54.5
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] setTargetTemperature IN_PROGRESS
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] io:PriorityLockOriginatorState => undefined
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] io:PriorityLockLevelState => undefined
[12/04/2021 à 09:21:05] [Cozytouch] [DHWP Actuator] setTargetTemperature ERRORCOMMAND
```


Et un souci au `computeStates() ` : ` this.device.get('core:OperatingModeState')` n'est parfois pas parsé et est une string, du coup quand on accède à `operatingMode.relaunch` on récupère undefined, ce qui est différent de `off` ...