### PR TITLE
Fix VenetianBlind.ts

### DIFF
--- a/src/mappers/VenetianBlind.ts
+++ b/src/mappers/VenetianBlind.ts
@@ -42,7 +42,7 @@ export default class VenetianBlind extends RollerShutter {
     }
 
     protected getTargetCommands(value): Command | Command[] {
-        if (!this.stateless) {
+        if (this.stateless) {
             if (value === 100) {
                 return new Command('open');
             } else if (value === 0) {


### PR DESCRIPTION
Bug has been introduced in https://github.com/dubocr/homebridge-tahoma/commit/b2fda5c91cc34f42b22a66b0df380196e889fc98

causing that `blindMode` does not work, only open/close state works for VenetianBlind. Not sure what was this change supposed to do but it is breaking change.